### PR TITLE
"HashiCorp" -> "hashicorp"

### DIFF
--- a/wsl/vagrant.sh
+++ b/wsl/vagrant.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Preparing Vagrant VMware"
 if [ ! -e /opt/vagrant-vmware-desktop ]; then
-  sudo ln -s /mnt/c/ProgramData/HashiCorp/vagrant-vmware-desktop /opt/vagrant-vmware-desktop
+  sudo ln -s /mnt/c/ProgramData/hashicorp/vagrant-vmware-desktop /opt/vagrant-vmware-desktop
 fi
 vagrant plugin install vagrant-vmware-desktop
 


### PR DESCRIPTION
Vorher bekam ich bei "vagrant up" eine Fehlermeldung, dass das Zertifikat von vagrant-vmware-desktop nicht gefunden wird. Der Link zeigt auf "...HashiCorp...", aber bei mir lautet der Verzeichnisname "...hashicorp...". Ich habe den vom Skript erstellten Link gelöscht und mit "sudo ln -s /mnt/c/ProgramData/hashicorp/vagrant-vmware-desktop /opt/vagrant-vmware-desktop" neu angelegt. Danach ging "vagrant up". Aber das ist vielleicht nur bei mir so ...